### PR TITLE
Wrong answer for 6th question

### DIFF
--- a/Convolutional Neural Networks/week2 quiz.md
+++ b/Convolutional Neural Networks/week2 quiz.md
@@ -50,9 +50,9 @@ a[l+2]=g(W[l+2]g(W[l+1]a[l]+b[l+1])+bl+2+_______ )+_______
 
 	A ResNet with L layers would have on the order of L2 skip connections in total.
 
-	> The skip-connections compute a complex non-linear function of the input to pass to a deeper layer in the network.
+	The skip-connections compute a complex non-linear function of the input to pass to a deeper layer in the network.
 
-	The skip-connection makes it easy for the network to learn an identity mapping between the input and the output within the ResNet block.
+	> The skip-connection makes it easy for the network to learn an identity mapping between the input and the output within the ResNet block.
 
 7. Suppose you have an input volume of dimension 64x64x16. How many parameters would a single 1x1 convolutional filter have (including the bias)?
 


### PR DESCRIPTION
the correct answer is 
The skip-connection makes it easy for the network to learn an identity mapping between the input and the output within the ResNet block. 